### PR TITLE
perf: optimize the active delta page cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,8 @@ add_executable(get_put_hashed_key "workload/exes/get_put_hashed_key.cc" ${letus_
 target_link_libraries(get_put_hashed_key OpenSSL::SSL OpenSSL::Crypto ${GNUC_LIBRARIES})
 add_executable(put_get_inter_hashed_key "workload/exes/put_get_inter_hashed_key.cc" ${letus_src})
 target_link_libraries(put_get_inter_hashed_key OpenSSL::SSL OpenSSL::Crypto ${GNUC_LIBRARIES})
+add_executable(simple_payment "workload/exes/simple_payment.cc" ${letus_src})
+target_link_libraries(simple_payment OpenSSL::SSL OpenSSL::Crypto ${GNUC_LIBRARIES})
 # add_executable(LSVPStest ${letus_tests})
 # target_link_libraries(LSVPStest letus GTest::GTest GTest::Main)
 

--- a/exps/perf.sh
+++ b/exps/perf.sh
@@ -1,20 +1,19 @@
 #!/bin/bash
-
 # 定义测试参数数组
-key_size=64  # 20:SHA-1, 32:SHA-256
+key_size=32  # 20:SHA-1, 32:SHA-256
+# batch_sizes=(500 1000 2000 3000 4000 5000)
+# batch_sizes=(100 200 300 400 500)
+batch_sizes=(4000)
 value_sizes=(1024)
-batch_sizes=(5000)
-n_test=5
+n_test=20
 data_path="$PWD/../data/"
 index_path="$PWD/../index"
 echo "data_path: $data_path"
 echo "index_path: $index_path"
 
-mode="debug"
-test_name="put_get_hist_count"
 # 编译项目
 cd ../
-./build.sh --build-type ${mode} --cxx g++
+./build.sh --build-type debug --cxx g++
 # 创建结果目录
 cd exps/
 mkdir -p results

--- a/exps/test_get_put_hashed_key.sh
+++ b/exps/test_get_put_hashed_key.sh
@@ -3,7 +3,7 @@ mode=release
 
 # 定义测试参数数组
 key_size=32  # 20:SHA-1, 32:SHA-256
-# batch_sizes=(500 1000 2000 3000 4000 5000)
+batch_sizes=(500 1000 2000 3000 4000 5000)
 # batch_sizes=(100 200 300 400 500)
 batch_sizes=(5000)
 value_sizes=(1024)

--- a/exps/test_simple_payment.sh
+++ b/exps/test_simple_payment.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+export ASAN_OPTIONS=detect_leaks=0
 # 编译项目
 cd ../
 ./build.sh
@@ -8,21 +8,18 @@ cd ../
 cd exps/
 mkdir -p results
 cd results
-mkdir -p get_put
+mkdir -p put_get_hist_count
 cd ..
 
 # 定义测试参数数组
 key_size=64
 batch_sizes=(500 1000 2000 3000 4000 5000)
 value_sizes=(256 512 1024 2048)
-n_test=8
+n_test=20
 data_path="$PWD/../data/"
 index_path="$PWD/../index"
 echo "data_path: $data_path"
 echo "index_path: $index_path"
-
-# 创建结果文件
-echo "batch_size,value_size,n_test,get_latency,put_latency,get_throughput,put_throughput" > results/get_put_results.csv
 
 # 运行测试
 for batch_size in "${batch_sizes[@]}"; do
@@ -34,17 +31,15 @@ for batch_size in "${batch_sizes[@]}"; do
         rm -rf $index_path
         mkdir -p $index_path
         
-        result_path="$PWD/results/get_put/b${batch_size}v${value_size}.csv"
+        result_path="$PWD/results/put_get_hist_count/b${batch_size}v${value_size}.csv"
         echo $(date "+%Y-%m-%d %H:%M:%S") >> results/test_get_put_hashed_key_k${key_size}_${mode}.log
         echo "batch_size: ${batch_size}, value_size: ${value_size}, key_size: ${key_size}" >> results/test_get_put_hashed_key_k${key_size}_${mode}.log
         # 运行测试并提取结果
-        ../build_release/bin/get_put -b $batch_size -k $key_size -v $value_size -n $n_test -d $data_path -i $index_path -r $result_path
+        ../build_release/bin/put_get_hist_count -b $batch_size -k $key_size -v $value_size -n $n_test -d $data_path -i $index_path -r $result_path
         
-        # 保存结果
-        echo "$batch_size,$value_size,$n_test,$put_latency,$get_latency,$put_throughput,$get_throughput" >> results/get_put_results.csv
         sleep 5
         set +x
     done
 done
 
-python3 plot.py get_put
+python3 plot.py put_get_hist_count

--- a/lib/DMMTrie.hpp
+++ b/lib/DMMTrie.hpp
@@ -182,6 +182,7 @@ class DeltaPage : public Page {
   void ClearBasePageUpdateCount();
   void SerializeTo(std::ofstream &out) const;
   bool Deserialize(std::ifstream &in);
+  bool Deserialize(char *buffer);
 
  private:
   vector<DeltaItem> deltaitems_;
@@ -249,7 +250,7 @@ class DMMTrie {
                 PageKey::Hash>
       lru_cache_;                             //  use a hash map as lru cache
   list<pair<PageKey, BasePage *>> pagekeys_;  // list to maintain cache order
-  const size_t max_cache_size_ = 300000;      // maximum pages in cache
+  const size_t max_cache_size_ = 3000000;      // maximum pages in cache
   unordered_map<string, DeltaPage>
       active_deltapages_;  // deltapage of all pages, delta pages are indexed by
                            // pid

--- a/lib/common.hpp
+++ b/lib/common.hpp
@@ -96,20 +96,28 @@ class Page {  // 设置成抽象类 序列化 反序列化 getPageKey setPageKey
               //  DMMTriePage DeltaPage
 
  private:
-  alignas(4096) char data_[PAGE_SIZE]{};
+  // alignas(4096) char data_[PAGE_SIZE]{};
+  char* data_;
   PageKey pagekey_;
 
  public:
-  Page() {}
+  Page() { data_ = nullptr; }
 
-  Page(PageKey pagekey) : pagekey_(pagekey) {}
+  Page(PageKey pagekey) : pagekey_(pagekey) { data_ = nullptr; }
 
   Page(const Page& other) {
-    memcpy(data_, other.data_, PAGE_SIZE);
+    // if (other.data_ != nullptr) {
+    //   data_ = new char[PAGE_SIZE];
+    //   memcpy(data_, other.data_, PAGE_SIZE);
+    // } else {
+    //   data_ = nullptr;
+    // }
+    data_ = nullptr;
     pagekey_ = other.pagekey_;
   }
 
-  virtual ~Page() = default;  // [hack]
+  // virtual ~Page() = default;  // [hack]
+  virtual ~Page() { delete[] data_; }
 
   const PageKey& GetPageKey() const {
     // std::cout << "[GetPageKey]" << pagekey_.pid << std::endl;
@@ -117,11 +125,15 @@ class Page {  // 设置成抽象类 序列化 反序列化 getPageKey setPageKey
   }
 
   // virtual size_t GetSerializedSize() = 0;
-
+  virtual void SerializeTo() {}
   virtual bool SerializeTo(std::ostream& out) const { return true; }
 
   virtual bool Deserialize(std::istream& in) {
     try {
+      if (data_ == nullptr) {
+        data_ = new char[PAGE_SIZE];
+        memset(data_, 0, PAGE_SIZE);
+      }
       in.read(data_, PAGE_SIZE);
       return in.good();
     } catch (const std::exception&) {
@@ -133,7 +145,18 @@ class Page {  // 设置成抽象类 序列化 反序列化 getPageKey setPageKey
 
   const char* GetData() const { return data_; }
 
-  char* GetData() { return data_; }
+  char* GetData() {
+    if (data_ == nullptr) {
+      data_ = new char[PAGE_SIZE];
+      memset(data_, 0, PAGE_SIZE);
+    }
+    return data_;
+  }
+
+  void ReleaseData() {
+    delete[] data_;
+    data_ = nullptr;
+  }
 };
 inline std::ostream& operator<<(std::ostream& os, const PageKey& key) {
   os << "PageKey(version=" << key.version << ", tid=" << key.tid

--- a/src/LSVPS.cpp
+++ b/src/LSVPS.cpp
@@ -155,26 +155,42 @@ bool LookupBlock::SerializeTo(std::ostream &out) const {
 
     // 1. 写入 entries 数量
     if (entries.size() > std::numeric_limits<uint32_t>::max()) {
+      std::cerr << "Error: too many lookup entries" << std::endl;
       return false;
     }
     uint32_t entriesSize = static_cast<uint32_t>(entries.size());
     out.write(reinterpret_cast<const char *>(&entriesSize),
               sizeof(entriesSize));
-    if (!out.good()) return false;
+    if (!out.good()) {
+      std::cerr << "Error: fail to write entriesSize" << std::endl;
+      return false;
+    }
 
     // 2. 写入所有 entries
     for (const auto &entry : entries) {
-      if (!entry.first.SerializeTo(out)) return false;
+      if (!entry.first.SerializeTo(out)) {
+        std::cerr << "Error: fail to write entry page key" << std::endl;
+        return false;
+      }
       out.write(reinterpret_cast<const char *>(&entry.second), sizeof(size_t));
-      if (!out.good()) return false;
+      if (!out.good()) {
+        std::cerr << "Error: fail to write entry location" << std::endl;
+        return false;
+      }
     }
 
     // 3. Calculate position within the LookupBlock
     std::streampos currentPos = out.tellp();
-    if (currentPos == std::streampos(-1)) return false;
+    if (currentPos == std::streampos(-1)) {
+      std::cerr << "Error: fail to get current position" << std::endl;
+      return false;
+    }
 
     size_t blockPos = static_cast<size_t>(currentPos - startPos);
-    if (blockPos > BLOCK_SIZE) return false;
+    if (blockPos > BLOCK_SIZE) {
+      std::cerr << "Error: read_size exceeds BLOCK_SIZE" << std::endl;
+      return false;
+    }
 
     size_t padding_size = BLOCK_SIZE - blockPos;
     std::vector<char> padding(padding_size, 0);
@@ -182,6 +198,7 @@ bool LookupBlock::SerializeTo(std::ostream &out) const {
 
     return out.good();
   } catch (const std::exception &) {
+    std::cerr << "Error: serialize lookup block failed" << std::endl;
     return false;
   }
 }
@@ -257,6 +274,7 @@ BasePage *LSVPS::LoadPage(const PageKey &pagekey) {
     uint64_t replay_version =
         trie_->GetVersionUpperbound(pagekey.pid, pagekey.version);
     delta_pagekey.version = replay_version;
+    // WARNING: 这个page有可能被flush所释放掉。
     DeltaPage *replay_sentinel =
         dynamic_cast<DeltaPage *>(pageLookup(delta_pagekey));
     if (replay_sentinel != nullptr) {
@@ -267,6 +285,7 @@ BasePage *LSVPS::LoadPage(const PageKey &pagekey) {
     }
   }
   while (current_pagekey.type) {
+    // WARNING: 这个page有可能被flush所释放掉。
     DeltaPage *delta_page = dynamic_cast<DeltaPage *>(
         pageLookup(current_pagekey));  // precisely search
     if (delta_page) {
@@ -279,6 +298,7 @@ BasePage *LSVPS::LoadPage(const PageKey &pagekey) {
   if (current_pagekey.version == 0)
     basepage = new BasePage(trie_, nullptr, pagekey.pid);
   else {
+    // WARNING: 这个page有可能被flush所释放掉。
     basepage = dynamic_cast<BasePage *>(pageLookup(current_pagekey));
     // TODO: leak here, basepage is not deleted but overwritten by new
     if (basepage == nullptr) {
@@ -533,6 +553,9 @@ void LSVPS::MemIndexTable::Flush() {
   parent_LSVPS_.AddIndexFile(
       {buffer_.front()->GetPageKey(), buffer_.back()->GetPageKey(), filepath});
 
+  for (auto page : buffer_) {
+    delete page;
+  }
   buffer_.clear();
 }
 
@@ -551,10 +574,12 @@ void LSVPS::MemIndexTable::writeToStorage(
       if (!page || !page->GetData()) {
         throw std::runtime_error("Invalid page data encountered");
       }
+      page->SerializeTo();
       outFile.write(reinterpret_cast<const char *>(page->GetData()), PAGE_SIZE);
       if (!outFile.good()) {
         throw std::runtime_error("Failed to write page data");
       }
+      // page->ReleaseData();
     }
 
     // 写入索引块
@@ -595,6 +620,12 @@ LSVPS::ActiveDeltaPageCache::ActiveDeltaPageCache(size_t max_size,
     std::ofstream out(cache_file_, std::ios::binary | std::ios::out);
     out.close();
   }
+
+  // prepare the page pool
+  page_pool_ = new DeltaPage[max_size_];
+  for (size_t i = 0; i < max_size_; ++i) {
+    free_pages_.push(i);
+  }
 }
 
 LSVPS::ActiveDeltaPageCache::~ActiveDeltaPageCache() {
@@ -606,27 +637,43 @@ LSVPS::ActiveDeltaPageCache::~ActiveDeltaPageCache() {
 
 void LSVPS::ActiveDeltaPageCache::Store(DeltaPage *page) {
   const string &pid = page->GetPageKey().pid;
-  // 检查是否需要淘汰
-  if (cache_.find(pid) == cache_.end()) {
-    evictIfNeeded();
-  }
-  // 存储新页面
-  if (page != cache_[pid]) {
-    delete cache_[pid];
-    cache_[pid] = page;
-  }
+  // // 检查是否需要淘汰
+  // if (cache_.find(pid) == cache_.end()) {
+  //   evictIfNeeded();
+  // }
+  // // 存储新页面
+  // if (page != cache_[pid]) {
+  //   page_pool_[it->second].ClearDeltaPage();
+  //   free_pages_.push(it->second);
+  //   // delete cache_[pid];
+  //   cache_[pid] = page;
+  // }
+  writePageToDisk(pid, page);
+  // delete page;
 }
 
 DeltaPage *LSVPS::ActiveDeltaPageCache::Get(const string &pid) {
   auto it = cache_.find(pid);
   if (it != cache_.end()) {
-    return it->second;
+    return &page_pool_[it->second];
   }
   // 如果不在内存中，尝试从磁盘读取
-  // TODO: cache operation here, avoid file confliction
-  DeltaPage *page = readFromDisk(pid);
+  // TODO: get page pointer from the pool
   evictIfNeeded();
-  cache_[pid] = page;
+  // deserilize into the page
+  size_t pool_pos = free_pages_.front();
+  DeltaPage *page = &page_pool_[pool_pos];
+  free_pages_.pop();
+  bool state = readFromDisk(pid, page);
+  // DeltaPage *page = readFromDisk(pid);
+
+  if (!state) {
+    // 如果读取失败，创建一个新的页面
+    page->ClearDeltaPage();
+    page->SetLastPageKey(PageKey{0, 0, false, pid});
+    page->SetPageKey(PageKey{0, 0, true, pid});
+  }
+  cache_.insert(std::make_pair(pid, pool_pos));
   return page;
 }
 
@@ -655,12 +702,14 @@ void LSVPS::ActiveDeltaPageCache::writePageToDisk(const string &pid,
   try {
     // 记录当前写入位置
     size_t offset;
-    if (pid_to_offset_.find(pid) != pid_to_offset_.end()) {
-      offset = pid_to_offset_[pid];
+    auto it = pid_to_offset_.find(pid);
+    if (it != pid_to_offset_.end()) {
+      offset = it->second;
       out.seekp(offset, ios::beg);
     } else {
       out.seekp(0, ios::end);
       offset = out.tellp();
+      pid_to_offset_.insert(std::make_pair(pid, offset));
     }
 
     // 写入页面数据
@@ -675,8 +724,9 @@ void LSVPS::ActiveDeltaPageCache::writePageToDisk(const string &pid,
 
     out.flush();
     out.close();
+
     // 更新pid到offset的映射
-    pid_to_offset_[pid] = offset;
+    // pid_to_offset_[pid] = offset;
   } catch (const std::exception &e) {
     out.close();
     throw;
@@ -689,9 +739,10 @@ void LSVPS::ActiveDeltaPageCache::evictIfNeeded() {
     auto it = cache_.begin();
     string pid_to_evict = it->first;
     // 写入磁盘
-    writePageToDisk(pid_to_evict, it->second);
+    // writePageToDisk(pid_to_evict, &page_pool_[it->second]);
     // 释放内存
-    delete it->second;
+    page_pool_[it->second].ClearDeltaPage();
+    free_pages_.push(it->second);
     cache_.erase(it);
   }
 }
@@ -808,8 +859,8 @@ void LSVPS::ActiveDeltaPageCache::readIndexBlock() {
 
 void LSVPS::ActiveDeltaPageCache::FlushToDisk() {
   // 先为所有页面准备偏移量
-  for (const auto &[pid, page] : cache_) {
-    prepareForBatchWrite(pid, page);
+  for (const auto &[pid, pool_pos] : cache_) {
+    prepareForBatchWrite(pid, &page_pool_[pool_pos]);
   }
 
   // 打开文件
@@ -821,20 +872,24 @@ void LSVPS::ActiveDeltaPageCache::FlushToDisk() {
 
   try {
     // 将所有缓存中的页面写入磁盘
-    for (const auto &[pid, page] : cache_) {
+    for (const auto &[pid, pool_pos] : cache_) {
       size_t offset;
-      if (pid_to_offset_.find(pid) != pid_to_offset_.end()) {
-        offset = pid_to_offset_[pid];
+      auto offset_it = pid_to_offset_.find(pid);
+      if (offset_it != pid_to_offset_.end()) {
+        offset = offset_it->second;
         out.seekp(offset, ios::beg);
       } else {
         out.seekp(0, ios::end);
         offset = out.tellp();
+        pid_to_offset_.insert(std::make_pair(pid, offset));
       }
 
-      if (!page || !page->GetData()) {
+      if (!page_pool_[pool_pos].GetData()) {
         throw std::runtime_error("Invalid page data encountered");
       }
-      out.write(reinterpret_cast<const char *>(page->GetData()), PAGE_SIZE);
+      page_pool_[pool_pos].SerializeTo();
+      out.write(reinterpret_cast<const char *>(page_pool_[pool_pos].GetData()),
+                PAGE_SIZE);
       if (!out.good()) {
         throw std::runtime_error("Failed to write page data");
       }
@@ -858,20 +913,21 @@ void LSVPS::StoreActiveDeltaPage(DeltaPage *page) {
 }
 DeltaPage *LSVPS::GetActiveDeltaPage(const string &pid) {
   DeltaPage *page = active_delta_page_cache_.Get(pid);
-  if (page == nullptr) {
-    page = new DeltaPage();
-    page->SetLastPageKey(PageKey{0, 0, false, pid});
-    page->SetPageKey(PageKey{0, 0, true, pid});
-    active_delta_page_cache_.Store(page);
-  }
+  // if (page == nullptr) {
+  //   page = new DeltaPage();
+  //   page->SetLastPageKey(PageKey{0, 0, false, pid});
+  //   page->SetPageKey(PageKey{0, 0, true, pid});
+  //   active_delta_page_cache_.Store(page);
+  // }
   return page;
 }
 
-DeltaPage *LSVPS::ActiveDeltaPageCache::readFromDisk(const string &pid) {
+bool LSVPS::ActiveDeltaPageCache::readFromDisk(const string &pid,
+                                               DeltaPage *page) {
   // 检查pid是否在索引中
   auto offset_it = pid_to_offset_.find(pid);
   if (offset_it == pid_to_offset_.end()) {
-    return nullptr;  // 页面不在磁盘上
+    return false;  // 页面不在磁盘上
   }
 
   // 打开文件
@@ -900,8 +956,10 @@ DeltaPage *LSVPS::ActiveDeltaPageCache::readFromDisk(const string &pid) {
     in.close();
 
     // 创建DeltaPage对象
-    DeltaPage *page = new DeltaPage(data);
+    // DeltaPage *page = new DeltaPage(data);
+    bool state = page->Deserialize(data);
 
+    delete[] data;
     // TODO: data is not deleted here
 
     // 将页面加入缓存
@@ -909,7 +967,7 @@ DeltaPage *LSVPS::ActiveDeltaPageCache::readFromDisk(const string &pid) {
     // evictIfNeeded();
     // cache_[pid] = page;
 
-    return page;
+    return state;
   } catch (const std::exception &e) {
     in.close();
     throw;

--- a/workload/exes/get_put.cc
+++ b/workload/exes/get_put.cc
@@ -20,7 +20,8 @@
 
 // common values
 uint64_t MAX_KEY = pow(2, 32) - 1;
-ZipfianGenerator key_generator(1, MAX_KEY);
+// ZipfianGenerator key_generator(1, MAX_KEY);
+CounterGenerator key_generator(1);
 
 struct Task {
   std::vector<int> ops;
@@ -72,9 +73,9 @@ int main(int argc, char** argv) {
   int batch_size = 60;  // 500, 1000, 2000, 3000, 4000
   int key_len = 5;      // 32
   int value_len = 256;  // 256, 512, 1024, 2048
-  std::string data_path = "/Users/ldz/Code/miniLETUS/data/";
-  std::string index_path = "/Users/ldz/Code/miniLETUS/";
-  std::string result_path = "/Users/ldz/Code/miniLETUS/exps/results/";
+  std::string data_path = "data/";
+  std::string index_path = "index";
+  std::string result_path = "exps/results/test.csv";
 
   int opt;
   while ((opt = getopt(argc, argv, "b:n:k:v:d:r:i:")) != -1) {

--- a/workload/exes/simple_payment.cc
+++ b/workload/exes/simple_payment.cc
@@ -1,0 +1,98 @@
+#include <sys/time.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "DMMTrie.hpp"
+#include "LSVPS.hpp"
+#include "generator.hpp"
+
+std::string BuildKeyName(uint64_t key_num, int key_len) {
+  std::string key_num_str = std::to_string(key_num);
+  int zeros = key_len - key_num_str.length();
+  zeros = std::max(0, zeros);
+  std::string key_name = "";
+  return key_name.append(zeros, '0').append(key_num_str);
+}
+
+int main(int argc, char** argv) {
+  int num_accout = 50000000;  // 40,000,000(40M) 2,000,000(2M)
+  int load_batch_size = 5000;
+  int num_txn = 10000;
+  int txn_batch_size = 1000;
+  int key_len = 64;
+  std::string data_path = "data/";
+  std::string index_path = "index";
+  std::string result_path = "exps/results/test.csv";
+
+  // init database
+  LSVPS* page_store = new LSVPS(index_path);
+  VDLS* value_store = new VDLS(data_path);
+  DMMTrie* trie = new DMMTrie(0, page_store, value_store);
+  page_store->RegisterTrie(trie);
+
+  // load data
+  int num_load_version = num_accout / load_batch_size;
+  int version = 1;
+  CounterGenerator key_generator(1);
+  for (; version <= num_load_version; version++) {
+    auto start = chrono::system_clock::now();
+    for (int i = 0; i < load_batch_size; i++) {
+      std::string key = BuildKeyName(key_generator.Next(), key_len);
+      std::string val = std::to_string(10);
+      trie->Put(0, version, key, val);
+    }
+    trie->Commit(version);
+    auto end = chrono::system_clock::now();
+    auto duration = chrono::duration_cast<chrono::microseconds>(end - start);
+    double load_latency = double(duration.count()) *
+                          chrono::microseconds::period::num /
+                          chrono::microseconds::period::den;
+    std::cout << "version " << version << ", load latnecy:" << load_latency
+              << ","
+              << "put throughput:" << load_batch_size / load_latency
+              << std::endl;
+  }
+
+  std::cout << "load " << num_accout << " accounts, current version is "
+            << version << std::endl;
+  // transaction
+  int num_txn_version = num_txn / txn_batch_size;
+  UniformGenerator txn_key_generator(1, num_accout);
+  for (; version <= num_load_version + num_txn_version; version++) {
+    auto start = chrono::system_clock::now();
+    for (int i = 0; i < txn_batch_size; i++) {
+      std::string key_send = BuildKeyName(txn_key_generator.Next(), key_len);
+      std::string key_recv = BuildKeyName(txn_key_generator.Next(), key_len);
+      DMMTrieProof proof_send = trie->GetProof(0, version - 1, key_send);
+      DMMTrieProof proof_recv = trie->GetProof(0, version - 1, key_recv);
+      int value_send = std::stoi(proof_send.value);
+      int value_recv = std::stoi(proof_recv.value);
+      if (value_send > 0) {
+        value_send -= 1;
+        value_recv += 1;
+      }
+      trie->Put(0, version, key_send, std::to_string(value_send));
+      trie->Put(0, version, key_recv, std::to_string(value_recv));
+    }
+
+    trie->Commit(version);
+    auto end = chrono::system_clock::now();
+    auto duration = chrono::duration_cast<chrono::microseconds>(end - start);
+    double txn_latency = double(duration.count()) *
+                         chrono::microseconds::period::num /
+                         chrono::microseconds::period::den;
+    std::cout << "transaction, version " << version
+              << " latnecy:" << txn_latency << ","
+              << "transaction throughput:" << txn_batch_size / txn_latency
+              << std::endl;
+  }
+  std::cout << "process " << num_txn << " transactions, current version is "
+            << version << std::endl;
+
+  return true;
+}


### PR DESCRIPTION
Allocate all the delta page at the beginning and not create new delta page Fix the data volume issue, adjust the number of mapping per block and memIndexTable size